### PR TITLE
Change course detail look

### DIFF
--- a/app/src/main/res/layout/fragment_course_detail.xml
+++ b/app/src/main/res/layout/fragment_course_detail.xml
@@ -4,7 +4,20 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
-	android:orientation="vertical">
+	android:orientation="vertical"
+	android:background="@color/colorPrimary">
+
+	<TextView
+		android:id="@+id/languageLabel"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_gravity="start"
+		android:textAlignment="center"
+		android:textColor="@color/colorTextWhite"
+		android:textSize="20sp"
+		android:paddingTop="4dp"
+		android:paddingBottom="4dp"
+		tools:text="Armenian"/>
 
 	<ImageView
 		android:id="@+id/flagImageView"
@@ -12,26 +25,15 @@
 		android:layout_height="200dp"
 		android:contentDescription="@string/flag_image"
 		android:scaleType="fitXY"
-		tools:src="@drawable/flag_armenian"/>
+		tools:src="@drawable/flag_armenian"
+		android:layout_below="@id/languageLabel"/>
 
-	<LinearLayout
+	<RelativeLayout
+		android:id="@+id/languageRow"
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
-		android:layout_alignBottom="@id/flagImageView"
-		android:alpha="0.9"
-		android:background="@color/colorPrimary"
-		android:orientation="horizontal">
-
-		<TextView
-			android:id="@+id/languageLabel"
-			android:layout_width="0dp"
-			android:layout_height="wrap_content"
-			android:layout_gravity="center"
-			android:layout_weight="1"
-			android:textAlignment="center"
-			android:textColor="@color/colorTextWhite"
-			android:textSize="20sp"
-			tools:text="Armenian"/>
+		android:orientation="horizontal"
+		android:layout_below="@id/flagImageView">
 
 		<ImageView
 			android:id="@+id/deleteIcon"
@@ -39,7 +41,8 @@
 			android:layout_height="40dp"
 			android:scaleType="center"
 			android:src="@drawable/ic_delete"
-			android:tint="@color/colorTextWhite"/>
+			android:tint="@color/colorTextWhite"
+			android:layout_alignParentEnd="true"/>
 
 		<ImageView
 			android:id="@+id/settingsIcon"
@@ -47,14 +50,15 @@
 			android:layout_height="40dp"
 			android:scaleType="center"
 			android:src="@drawable/ic_settings"
-			android:tint="@color/colorTextWhite"/>
-	</LinearLayout>
+			android:tint="@color/colorTextWhite"
+            android:layout_toLeftOf="@id/deleteIcon"/>
+	</RelativeLayout>
 
 	<LinearLayout
 		android:id="@+id/recyclerView"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
-		android:layout_below="@id/flagImageView"
+		android:layout_below="@id/languageRow"
 		android:background="@color/colorPrimary"
 		android:gravity="center_horizontal"
 		android:orientation="vertical"


### PR DESCRIPTION
On some flags it looks a bit strange when we write the name of the
language over the flag. It looks like the flag is smaller than it should
be because the alpha of 0.9 looks sometimes so dense that I didn't
realize that the flag continues behind it.

I experimented a bit with the look and now changed it so the language is
displayed above the flag.

This is what it looks like:

![natibo](https://user-images.githubusercontent.com/1658215/50075551-90315e00-01df-11e9-8eb2-d6de1c512b3a.jpg)