### PR TITLE
Change app id and name for debug version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,10 @@ android {
 			minifyEnabled true
 			proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 		}
+		debug {
+			applicationIdSuffix '.debug'
+			versionNameSuffix ' DEBUG '
+		}
 	}
 }
 

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Natibo DEBUG</string>
+</resources>


### PR DESCRIPTION
Right now, developers who are learning with Natibo have to manually change the application Id when debugging Natibo on their own device, since otherwise they would have to reinstall Natibo upon debugging and their learning progress would be lost.

I added an application id suffix and an application name suffix for the debug version to allow developers to have a release and a debug version installed on their device in parallel without having to manually change anything.