### PR TITLE
Disallow orientation change to landscape mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
 		android:label="@string/app_name"
 		android:supportsRtl="true"
 		android:theme="@style/AppTheme">
-		<activity android:name=".MainActivity">
+		<activity android:name=".MainActivity" android:screenOrientation="portrait">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
Previously in the StudySession fragment, an orientation change resulted in the app crashing. In the CourseDetail fragment, an orientation change took the user back to the previous fragment.
This commit enforces portrait mode in the entire app to prevent these things from happening.
Since in landscape mode some fragments anyhow don't fit into the screen of some phones, I think this solution is preferable over the way things are right now. That way, this could be a (temporary) solution for #9 .