### PR TITLE
Change Study Session Overview look

### DIFF
--- a/app/src/main/res/layout/fragment_study_session_overview.xml
+++ b/app/src/main/res/layout/fragment_study_session_overview.xml
@@ -12,13 +12,16 @@
 		android:layout_height="wrap_content"
 		android:textAlignment="center"
 		android:textSize="20sp"
+		android:layout_marginTop="8dp"
+		android:layout_marginBottom="4dp"
 		tools:text="Armenian"/>
 
 
 	<TextView
-		android:layout_width="wrap_content"
+		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:textSize="16sp"
+		android:textAlignment="center"
 		android:text="Sentences Studied"/>
 
 	<android.support.v7.widget.RecyclerView


### PR DESCRIPTION
This adds a top and bottom margin to the courseTitleText TextView and centers the "Sentences Studied" TextView.

Previous version vs. new version:

![natibo_compare](https://user-images.githubusercontent.com/5568910/52166797-46122680-2712-11e9-9365-b0f2e3ad712f.jpg)
