### PR TITLE
Properly handle audio focus changes

### DIFF
--- a/app/src/main/java/ch/ralena/natibo/fragment/StudySessionFragment.java
+++ b/app/src/main/java/ch/ralena/natibo/fragment/StudySessionFragment.java
@@ -93,6 +93,10 @@ public class StudySessionFragment extends Fragment {
 		// handle playing/pausing
 		playPauseImage.setOnClickListener(this::playPause);
 
+		// connect to the studySessionService and start the session
+		connectToService();
+		activity.startSession(course);
+
 		return view;
 	}
 
@@ -132,7 +136,6 @@ public class StudySessionFragment extends Fragment {
 			updateTime();
 			updatePlayPauseImage();
 		});
-		activity.startSession(course);
 	}
 
 	private void playPause(View view) {
@@ -191,6 +194,10 @@ public class StudySessionFragment extends Fragment {
 	private void startTimer() {
 		millisLeft = millisLeft - millisLeft % 1000 - 1;
 		updateTime();
+		// Make sure no two active timers are displayed at the same time
+		if (countDownTimer != null) {
+			countDownTimer.cancel();
+		}
 		countDownTimer = new CountDownTimer(millisLeft, 100) {
 			@Override
 			public void onTick(long millisUntilFinished) {

--- a/app/src/main/java/ch/ralena/natibo/service/StudySessionService.java
+++ b/app/src/main/java/ch/ralena/natibo/service/StudySessionService.java
@@ -267,12 +267,14 @@ public class StudySessionService extends Service implements MediaPlayer.OnComple
 	}
 
 	public void resume() {
-		playbackStatus = PlaybackStatus.PLAYING;
-		if (mediaPlayer != null && !mediaPlayer.isPlaying()) {
-			mediaPlayer.start();
-		} else {
-			loadSentence();
-			play();
+		if (requestAudioFocus()) {
+			playbackStatus = PlaybackStatus.PLAYING;
+			if (mediaPlayer != null && !mediaPlayer.isPlaying()) {
+				mediaPlayer.start();
+			} else {
+				loadSentence();
+				play();
+			}
 		}
 	}
 

--- a/app/src/main/java/ch/ralena/natibo/service/StudySessionService.java
+++ b/app/src/main/java/ch/ralena/natibo/service/StudySessionService.java
@@ -108,9 +108,6 @@ public class StudySessionService extends Service implements MediaPlayer.OnComple
 			stopSelf();
 
 		if (mediaPlayer == null) {
-			mediaPlayer = new MediaPlayer();
-			mediaPlayer.setOnCompletionListener(this);
-			mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
 			loadSentence();
 			play();
 		}
@@ -169,6 +166,11 @@ public class StudySessionService extends Service implements MediaPlayer.OnComple
 		} else {
 			sentencePublish.onNext(sentenceGroup);
 			sentence = day.getCurrentSentence();
+			if (mediaPlayer == null) {
+				mediaPlayer = new MediaPlayer();
+				mediaPlayer.setOnCompletionListener(this);
+				mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
+			}
 			try {
 				mediaPlayer.stop();
 				mediaPlayer.reset();
@@ -269,7 +271,8 @@ public class StudySessionService extends Service implements MediaPlayer.OnComple
 		if (mediaPlayer != null && !mediaPlayer.isPlaying()) {
 			mediaPlayer.start();
 		} else {
-			nextSentence();
+			loadSentence();
+			play();
 		}
 	}
 
@@ -453,8 +456,9 @@ public class StudySessionService extends Service implements MediaPlayer.OnComple
 					restartPlaying();
 				break;
 			case AudioManager.AUDIOFOCUS_LOSS:        // we've lost focus indefinitely
-				isPlaying = playbackStatus == PlaybackStatus.PLAYING;
+				isPlaying = false;
 				pauseAndRelease();
+				buildNotification();
 				break;
 			case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:    // we've lost focus for a short amount of time, e.g. Google Maps announcing directions
 			case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:    // we've lost focus for a short amount of time but we can still play audio in bg


### PR DESCRIPTION
Previously, the app crashed when it lost audio focus because another app requested the focus. This was because upon audio focus loss, mediaPlayer was set to null and was not initialized again when regaining focus and resuming playback. Now mediaPlayer is being initialized in loadSentences() if it is null.

Because the app started playing automatically when another app had the audio focus and the power
button was pressed to activate the lock screen (this lead to onResume() being called), I removed
startSession() from connectToService() and instead call it separately in onCreateView().

Also, the app now requests audio focus every time when resuming playback. This prevents
other apps from continuing to play audio when Natibo starts playing.