### PR TITLE
Add option in settings to change playback speed

### DIFF
--- a/app/src/main/java/ch/ralena/natibo/fragment/CourseSettingsFragment.java
+++ b/app/src/main/java/ch/ralena/natibo/fragment/CourseSettingsFragment.java
@@ -20,6 +20,7 @@ Settings:
 public class CourseSettingsFragment extends PreferenceFragmentCompat {
 	public static final String PREF_PAUSE = "pref_pause";
 	public static final String PREF_START = "pref_start";
+	public static final String PREF_SPEED = "pref_playback_speed";
 	public static final String KEY_ID = "key_id";
 
 	private SharedPreferences prefs;
@@ -33,6 +34,16 @@ public class CourseSettingsFragment extends PreferenceFragmentCompat {
 				case PREF_PAUSE:
 					realm.executeTransaction(r -> {
 						course.setPauseMillis(Integer.parseInt(sharedPreferences.getString(PREF_PAUSE, "1000")));
+					});
+					break;
+				case PREF_SPEED:
+					realm.executeTransaction(r -> {
+						float speed = Float.parseFloat(sharedPreferences.getString(getString(R.string.playback_speed_key), getString(R.string.playback_speed_default)));
+						// Set speed to the allowed range between 0.5 and 2.5 and round to one decimal place
+						speed = speed < 0.5 ? 0.5f : speed;
+						speed = speed > 2.5 ? 2.5f : speed;
+						speed = Math.round(speed*10) / 10f;
+						course.setPlaybackSpeed(speed);
 					});
 					break;
 			}
@@ -73,6 +84,7 @@ public class CourseSettingsFragment extends PreferenceFragmentCompat {
 		// load preferences from course into our shared preferences
 		prefs.edit()
 				.putString(PREF_PAUSE, course.getPauseMillis() + "")
+				.putString(PREF_SPEED, course.getPlaybackSpeed() + "")
 				.apply();
 		prefs.registerOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
 

--- a/app/src/main/java/ch/ralena/natibo/object/Course.java
+++ b/app/src/main/java/ch/ralena/natibo/object/Course.java
@@ -46,6 +46,7 @@ public class Course extends RealmObject {
 	private Day currentDay;
 	private int numReps;
 	private int pauseMillis;
+	private float playbackSpeed = 1;
 	private RealmList<Day> pastDays = new RealmList<>();
 	private Schedule schedule = new Schedule();    // the different pieces that make up the study routine for each day
 	private RealmList<Sentence> sentencesSeen = new RealmList<>();    // keep track of which sentences have been seen and which haven't
@@ -101,6 +102,17 @@ public class Course extends RealmObject {
 		if (currentDay != null)
 			currentDay.setPauseMillis(pauseMillis);
 	}
+
+	public float getPlaybackSpeed() {
+	    return playbackSpeed;
+    }
+
+    public void setPlaybackSpeed(float playbackSpeed) {
+	    this.playbackSpeed = playbackSpeed;
+	    if (currentDay != null) {
+	        currentDay.setPlaybackSpeed(playbackSpeed);
+        }
+    }
 
 	public RealmList<Day> getPastDays() {
 		return pastDays;
@@ -173,6 +185,7 @@ public class Course extends RealmObject {
 			day.getSentenceSets().add(sentenceSet);
 			day.setCompleted(false);
 			day.setPauseMillis(pauseMillis);
+			day.setPlaybackSpeed(playbackSpeed);
 			currentDay = day;
 		});
 		List<SentenceSet> emptySentenceSets = new ArrayList<>();

--- a/app/src/main/java/ch/ralena/natibo/object/Day.java
+++ b/app/src/main/java/ch/ralena/natibo/object/Day.java
@@ -18,6 +18,7 @@ public class Day extends RealmObject {
 	private RealmList<SentenceSet> sentenceSets = new RealmList<>();
 	private boolean isCompleted;
 	private int pauseMillis;
+	private float playbackSpeed;
 
 	// internal fields
 	private int curSentenceSetId;
@@ -53,6 +54,8 @@ public class Day extends RealmObject {
 	public void setPauseMillis(int pauseMillis) {
 		this.pauseMillis = pauseMillis;
 	}
+
+	public void setPlaybackSpeed(float playbackSpeed) { this.playbackSpeed = playbackSpeed; }
 
 	// --- helper methods ---
 
@@ -180,7 +183,11 @@ public class Day extends RealmObject {
 	public int getTimeLeft() {
 		int millisecondsLeft = 0;
 		for (Sentence sentence : getRemainingSentences()) {
-			millisecondsLeft += sentence.getTimeInMillis() + pauseMillis;
+			if (true) {  // TODO: condition should evaluate to true if the sentence is from the base language
+				millisecondsLeft += sentence.getTimeInMillis() + pauseMillis;
+			} else {
+				millisecondsLeft += sentence.getTimeInMillis() * playbackSpeed + pauseMillis;
+			}
 		}
 
 		return millisecondsLeft;

--- a/app/src/main/java/ch/ralena/natibo/object/Sentence.java
+++ b/app/src/main/java/ch/ralena/natibo/object/Sentence.java
@@ -20,6 +20,8 @@ public class Sentence extends RealmObject {
 	private String uri;            // mp3 location
 	private int timeInMillis;            // timeInMillis of mp3 in ms
 
+	public String getId() { return id; }
+
 	public int getIndex() {
 		return index;
 	}

--- a/app/src/main/java/ch/ralena/natibo/service/StudySessionService.java
+++ b/app/src/main/java/ch/ralena/natibo/service/StudySessionService.java
@@ -176,6 +176,17 @@ public class StudySessionService extends Service implements MediaPlayer.OnComple
 				mediaPlayer.reset();
 				// load sentence path into mediaplayer to be played
 				mediaPlayer.setDataSource(sentence.getUri());
+
+				// Set playback speed for the target language according to preferences
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+					// Only change playback speed for the target language
+					if (sentence.getId().equals(sentenceGroup.getSentences().get(1).getId())) {
+						mediaPlayer.setPlaybackParams(mediaPlayer.getPlaybackParams().setSpeed(course.getPlaybackSpeed()));
+					} else {
+						mediaPlayer.setPlaybackParams(mediaPlayer.getPlaybackParams().setSpeed(1f));
+					}
+				}
+
 				mediaPlayer.prepare();
 			} catch (IOException | IllegalStateException e) {
 				e.printStackTrace();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,4 +55,8 @@
 	<string name="target">%s - target %d</string>
 	<string name="session_in_progress">Session in progress!</string>
 	<string name="reset_session">This will reset your current session, are you sure?</string>
+    <string name="playback_speed">Playback speed</string>
+    <string name="playback_speed_key" translatable="false">pref_playback_speed</string>
+	<string name="playback_speed_summary">The playback speed for the target language. Maximum value is normal speed.</string>
+	<string name="playback_speed_default" translatable="false">1.0</string>
 </resources>

--- a/app/src/main/res/xml-v23/course_settings.xml
+++ b/app/src/main/res/xml-v23/course_settings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+	<PreferenceCategory
+		android:title="Course Settings">
+
+		<EditTextPreference
+			android:defaultValue="1000"
+			android:inputType="number"
+			android:key="pref_pause"
+			android:summary="@string/time_in_milliseconds"
+			android:title="@string/pause_between_sentences"/>
+
+		<EditTextPreference
+			android:defaultValue="@string/playback_speed_default"
+			android:inputType="numberDecimal"
+			android:key="@string/playback_speed_key"
+			android:summary="@string/playback_speed_summary"
+			android:title="@string/playback_speed"/>
+
+	</PreferenceCategory>
+	<PreferenceCategory
+		android:title="Progress">
+
+		<Preference
+			android:key="pref_start"
+			android:summary="@string/where_to_start"
+			android:title="@string/change_starting_point"/>
+
+	</PreferenceCategory>
+</PreferenceScreen>


### PR DESCRIPTION
This allows the user to adjust the playback speed of the target language audio. The option is only shown for API > 23.
This is related to #20.

One thing that is not properly working yet is that the remaining study time is not adjusted correctly when changing the playback speed. In Day.java, L186: I couldn't think of a clean way to check whether a sentence is from the base or the target language and therefore whether to multiply the sentence time with the adjusted playback speed or not. But maybe with the proper understanding of the code base this is not as difficult. Can you think of something @chickendude ?